### PR TITLE
Update Dockerfile and Pysam function calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ WORKDIR /opt
 
 RUN pip install tox && tox -p
 
+# Remove tar.gz built from 'testenv:check_dist' step in tox.ini
+RUN rm *+dirty.tar.gz
+
 FROM python:3.10
 
 COPY --from=builder /opt/dist/*.tar.gz /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /opt
 RUN pip install tox && tox -p
 
 # Remove tar.gz built from 'testenv:check_dist' step in tox.ini
-RUN rm *+dirty.tar.gz
+RUN rm ./dist/*+dirty.tar.gz
 
 FROM python:3.10
 

--- a/bam_readgroup_to_json/main.py
+++ b/bam_readgroup_to_json/main.py
@@ -32,7 +32,7 @@ def extract_readgroup_json(bam_path: str, logger: logging.Logger) -> None:
     bam_name, _ = os.path.splitext(bam_file)
     samfile = pysam.AlignmentFile(bam_path, 'rb', check_sq=False)
     samfile_header = samfile.header
-    readgroup_dict_list = samfile_header['RG']
+    readgroup_dict_list = samfile_header.to_dict()['RG']
     if len(readgroup_dict_list) < 1:
         logger.debug(f'There are no readgroups in BAM: {bam_name}')
         logger.debug(f'\treadgroup: {readgroup_dict_list}')
@@ -71,8 +71,8 @@ def legacy_extract_readgroup_json(bam_path: str, logger: logging.Logger) -> None
     bam_file = os.path.basename(bam_path)
     bam_name, bam_ext = os.path.splitext(bam_file)
     samfile = pysam.AlignmentFile(bam_path, 'rb', check_sq=False)
-    samfile_header = samfile.text
-    header_list = samfile_header.split('\n')
+    samfile_header = samfile.header
+    header_list = samfile_header.to_dict().keys()
     header_rg_list = [
         header_line for header_line in header_list if header_line.startswith('@RG')
     ]


### PR DESCRIPTION
# Addressed Issue
- Address [bam_readgroup_to_json build incomplete #4 ](https://github.com/ohsu-comp-bio/wgs-pipelines/issues/4)

# Changes
- Removes tar.gz file built from 'testenv:check_dist' step in tox.ini that was causing an error in the `RUN pip install -r requirements.txt *.tar.gz` line in the Dockerfile.
- Updates two function calls to pysam to match updated versions (related issue: https://github.com/pysam-developers/pysam/issues/618)

# Tests
- Ran `docker build -t bam_readgroup_to_json . successfully, can push built image to Quay.io or Dockerhub if that would be helpful.

```sh
➜  bam_readgroup_to_json git:(master) docker build -t bam_readgroup_to_json .
[+] Building 175.5s (15/15) FINISHED                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 589B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/library/python:3.10                                     0.8s
 => [internal] load build context                                                                  2.7s
 => => transferring context: 3.71MB                                                                2.6s
 => [builder 1/6] FROM docker.io/library/python:3.10@sha256:1a8dcc07368065c2b285b24236a98e80355d6  0.0s
 => CACHED [builder 2/6] RUN python3 -m venv /home/ubuntu/merge-sqlite/docker_test_env             0.0s
 => [builder 3/6] COPY ./ /opt                                                                     4.8s
 => [builder 4/6] WORKDIR /opt                                                                     0.0s
 => [builder 5/6] RUN pip install tox && tox -p                                                  164.7s
 => [builder 6/6] RUN rm ./dist/*+dirty.tar.gz                                                     0.2s
 => CACHED [stage-1 2/5] COPY --from=builder /opt/dist/*.tar.gz /opt                               0.0s
 => CACHED [stage-1 3/5] COPY requirements.txt /opt                                                0.0s
 => CACHED [stage-1 4/5] WORKDIR /opt                                                              0.0s
 => CACHED [stage-1 5/5] RUN pip install -r requirements.txt *.tar.gz  && rm -f *.tar.gz requirem  0.0s
 => exporting to image                                                                             0.0s
 => => exporting layers                                                                            0.0s
 => => writing image sha256:e526e08c1bd62a9ce10618b0c733bbcaa3a24f9ebfd2f23597534524bcf4ed7e       0.0s
 => => naming to docker.io/library/bam_readgroup_to_json                                           0.0s                                                 0.0s
```